### PR TITLE
Change velocity timestamp format to `u64`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/ostenning/rotary-encoder-embedded"
 
 [dependencies]
 embedded-hal = { version = "0.2.7", features = ["unproven"] }
-chrono = { version = "0.4.19", default-features = false }
 
 [features]
 angular-velocity = []

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ fn main() -> ! {
     loop {
         // Update the encoder which will compute its direction and velocity
         // As velocity is a function of time, we need the current time
-        // current_time should be derived from the RTC and SysTick
+        // current_time should be a monotonously rising time in ms (akin to Arduino's `millis()`)
         rotary_encoder.update(current_time);
         // Get the velocity
         let velocity = rotary_encoder.velocity();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,8 +165,8 @@ where
     /// This function will reduce the angular velocity over time, the amount is configurable via the constructor
     pub fn decay_velocity(&mut self) {
         self.velocity -= self.velocity_dec_factor;
-        if self.velocity < -1.0 {
-            self.velocity = -1.0;
+        if self.velocity < 0.0 {
+            self.velocity = 0.0;
         }
     }
 
@@ -200,6 +200,9 @@ where
         if self.inner.direction() != Direction::None {
             if current_time - self.previous_time < self.velocity_action_ms && self.velocity < 1.0 {
                 self.velocity += self.velocity_inc_factor;
+                if self.velocity > 1.0 {
+                    self.velocity = 1.0;
+                }
             }
             return;
         }
@@ -216,10 +219,6 @@ where
     /// The Angular Velocity is a value between 0.0 and 1.0
     /// This is useful for incrementing/decrementing a value in an exponential fashion
     pub fn velocity(&self) -> Velocity {
-        if self.velocity < 0.0 {
-            0.0
-        } else {
-            self.velocity
-        }
+        self.velocity
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,14 +70,14 @@ where
 {
     /// Initiates a new Rotary Encoder, taking two InputPins [`InputPin`](https://docs.rs/embedded-hal/0.2.3/embedded_hal/digital/v2/trait.InputPin.html).
     pub fn new(pin_dt: DT, pin_clk: CLK) -> Self {
-        return RotaryEncoder {
+        RotaryEncoder {
             pin_dt,
             pin_clk,
             pos_calc: 0,
             transition: 0,
             sensitivity: Sensitivity::Default,
             direction: Direction::None,
-        };
+        }
     }
 
     /// Set the sensitivity of the rotary encoder
@@ -104,7 +104,7 @@ where
         let current = (dt_state << 1) | clk_state;
         self.transition = (self.transition << 2) | current;
         let index = (self.transition & 0x0F) as usize;
-        self.pos_calc = self.pos_calc + STATES[index];
+        self.pos_calc += STATES[index];
 
         let sensitivity = self.sensitivity as i8;
         if self.pos_calc == sensitivity || self.pos_calc == -sensitivity {
@@ -216,10 +216,10 @@ where
     /// The Angular Velocity is a value between 0.0 and 1.0
     /// This is useful for incrementing/decrementing a value in an exponential fashion
     pub fn velocity(&self) -> Velocity {
-        return if self.velocity < 0.0 {
+        if self.velocity < 0.0 {
             0.0
         } else {
             self.velocity
-        };
+        }
     }
 }


### PR DESCRIPTION
This PR remove the dependency on `chrono` just uses `u64`s to keep track of the velocity timestamps internally. You could still use `chrono` for this externally and pass the result of the `timestamp_millis()` function into the `update` function. Keep in mind that it has to be greater than 0 (after epoch) and hence an `u64` instead of and `i64`.

I also fixed some things for which I got yelled at by clippy.