### PR TITLE
docs: fix typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ fn timer_interrupt_handler() {
         Direction::Clockwise => {
             // Increment some value
         }
-        Direction::AntiClockwise => {
+        Direction::Anticlockwise => {
             // Decrement some value
         }
         Direction::None => {


### PR DESCRIPTION
There is small typo in the example in README. 
Fixed to make it buildable.