### PR TITLE
Update to embedded-hal 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 repository = "https://github.com/ost-ing/rotary-encoder-embedded"
 
 [dependencies]
-embedded-hal = { version = "0.2.7", features = ["unproven"] }
+embedded-hal = { version = "1.0.0"}
 
 [dev-dependencies]
-embedded-hal-mock = { version = "0.10.0", features = ["eh0"] }
+embedded-hal-mock = { version = "0.11.*", features = ["eh1"] }

--- a/src/angular_velocity.rs
+++ b/src/angular_velocity.rs
@@ -1,4 +1,4 @@
-use embedded_hal::digital::v2::InputPin;
+use embedded_hal::digital::InputPin;
 
 use crate::Direction;
 use crate::RotaryEncoder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 #![deny(warnings)]
 #![no_std]
 
-use embedded_hal::digital::v2::InputPin;
+use embedded_hal::digital::InputPin;
 
 /// Angular velocity api
 pub mod angular_velocity;
@@ -77,7 +77,7 @@ mod test {
     use crate::{
         angular_velocity::AngularVelocityMode, standard::StandardMode, Direction, RotaryEncoder,
     };
-    use embedded_hal_mock::eh0::pin::{Mock, State, Transaction};
+    use embedded_hal_mock::eh1::digital::{Mock, State, Transaction};
 
     #[test]
     fn standard_mode_api() {

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -1,4 +1,4 @@
-use embedded_hal::digital::v2::InputPin;
+use embedded_hal::digital::InputPin;
 
 use crate::Direction;
 use crate::RotaryEncoder;


### PR DESCRIPTION
Update to embedded-hal 1.0.0 to support current HALs.
Tested on an esp32s3 using esp_hal.